### PR TITLE
PP-80 fixed missing routes

### DIFF
--- a/src/main/java/de/htw/gateway/config/SecurityConfig.java
+++ b/src/main/java/de/htw/gateway/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package de.htw.gateway.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.oauth2.server.resource.authentication.ReactiveJwtAuthenticationConverter;
@@ -33,6 +34,8 @@ public class SecurityConfig {
             }))
             .csrf(csrfSpec -> csrfSpec.disable())
             .authorizeExchange(authorize -> authorize
+                    .pathMatchers(HttpMethod.GET, "/products/**").permitAll()
+                    .pathMatchers("/baskets/**").permitAll()
                     .pathMatchers("/open").permitAll()
                     .pathMatchers("/user").hasRole("USER")
                     .pathMatchers("/admin").hasRole("ADMIN")


### PR DESCRIPTION
- Added routes by using double wildcard syntax (**) to allow for the path itself and all "sub-paths" (e.g. /products & /products/{id})
- Included path matchers for certain HTTP methods